### PR TITLE
fix(CMake): Add missing link to libm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -z noexecstack")
 endif()
 
 add_library(osal ${SRC_OSAL})
+if(BUILD_FOR_PLATFORM STREQUAL "POSIX")
 target_link_libraries(osal m)
+endif()
 target_include_directories(osal 
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -z noexecstack")
 endif()
 
 add_library(osal ${SRC_OSAL})
-
+target_link_libraries(osal m)
 target_include_directories(osal 
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  


### PR DESCRIPTION
Linking against libm is required when building with `BUILD_SHARED_LIBS=ON`.