### PR TITLE
fix(CMake): Use always -fpic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(CMakePackageConfigHelpers)
 
 option(BUILD_FOR_PLATFORM "Set to WIN32, MINGW32, PIKEOS, POSIX, or VXWORKS" "")
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+option(BUILD_WITH_POSITION_INDEPENDENT_CODE "Build using fpic flag" OFF)
 
 if(BUILD_FOR_PLATFORM STREQUAL "POSIX")
     set(LIBOSAL_BUILD_POSIX 1)
@@ -151,7 +152,7 @@ target_include_directories(osal
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  
         $<INSTALL_INTERFACE:include>)
-set_property(TARGET osal PROPERTY POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+set_property(TARGET osal PROPERTY POSITION_INDEPENDENT_CODE ${BUILD_WITH_POSITION_INDEPENDENT_CODE})
 
 
 write_basic_package_version_file(

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ sudo make install
 This will build and install a static as well as a dynamic library. For use in other project you can you the generated pkg-config file to retreave cflags and linker flags.
 
 ## Build with CMake
+
 ```bash
 mkdir build
 cd build
@@ -35,7 +36,7 @@ cmake --build .
 cmake --install . 
 ```
 
-#### Configuration parameters
+### Configuration parameters
 
 | Parameter                            | Default | Description                                                               |
 |--------------------------------------|---------|---------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -29,11 +29,20 @@ This will build and install a static as well as a dynamic library. For use in ot
 mkdir build
 cd build
 # You can choose MINGW32, POSIX, WIN32, PIKEOS, or VXWORKS. No cross compile currently supported with CMake
-cmake .. -DBUILD_FOR_PLATFORM="POSIX"
+cmake -DBUILD_FOR_PLATFORM="POSIX" -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 # You can define a specific install path with e.g. cmake --install .  --prefix test
 cmake --install . 
 ```
+
+#### Configuration parameters
+
+| Parameter                            | Default | Description                                                               |
+|--------------------------------------|---------|---------------------------------------------------------------------------|
+| BUILD_FOR_PLATFORM                   |         | Select manually your platform (WIN32, MINGW32, PIKEOS, POSIX, or VXWORKS) |
+| BUILD_SHARED_LIBS                    |   OFF   | Flag to build shared libraries instead of static ones.                    |
+| BUILD_WITH_POSITION_INDEPENDENT_CODE |   OFF   | Flag to build with -fpic option´. Required for shared libs                |
+
 
 ## Tests
 


### PR DESCRIPTION
Linking libethercat in cmake against a static libosal fails if fpic is not set in the libosal.
Therefore, fpic is used to build both static and dynamic libs.